### PR TITLE
Avoid use of pg_advisory_lock

### DIFF
--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBConnection.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBConnection.java
@@ -34,6 +34,6 @@ public class YugabyteDBConnection extends PostgreSQLConnection {
 
     @Override
     public <T> T lock(Table table, Callable<T> callable) {
-        return new YugabyteDBExecutionTemplate(database.getConfiguration(), jdbcTemplate, table.toString().hashCode()).execute(callable);
+        return new YugabyteDBExecutionTemplate(database.getConfiguration(), jdbcTemplate, table.toString()).execute(callable);
     }
 }

--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBConnection.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBConnection.java
@@ -16,7 +16,10 @@
 package org.flywaydb.community.database.postgresql.yugabytedb;
 
 import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.core.internal.database.base.Table;
 import org.flywaydb.database.postgresql.PostgreSQLConnection;
+
+import java.util.concurrent.Callable;
 
 public class YugabyteDBConnection extends PostgreSQLConnection {
 
@@ -27,5 +30,10 @@ public class YugabyteDBConnection extends PostgreSQLConnection {
     @Override
     public Schema getSchema(String name) {
         return new YugabyteDBSchema(jdbcTemplate, (YugabyteDBDatabase) database, name);
+    }
+
+    @Override
+    public <T> T lock(Table table, Callable<T> callable) {
+        return new YugabyteDBExecutionTemplate(database.getConfiguration(), jdbcTemplate, table.toString().hashCode()).execute(callable);
     }
 }

--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
@@ -77,7 +77,7 @@ public class YugabyteDBDatabase extends PostgreSQLDatabase {
 
     private void init() {
         try {
-            jdbcTemplate.execute("CREATE TABLE IF NOT EXISTS " + LOCK_TABLE_NAME + " (table_hash int PRIMARY KEY, locked bool, last_updated timestamp);");
+            jdbcTemplate.execute("CREATE TABLE IF NOT EXISTS " + LOCK_TABLE_NAME + " (table_name varchar PRIMARY KEY, locked bool, last_updated timestamp);");
         } catch (SQLException e) {
             throw new FlywaySqlException("Unable to initialize the lock table", e);
         }

--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
@@ -18,31 +18,26 @@ package org.flywaydb.community.database.postgresql.yugabytedb;
 import lombok.CustomLog;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.exception.FlywaySqlException;
 import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
 import org.flywaydb.core.internal.jdbc.StatementInterceptor;
 import org.flywaydb.database.postgresql.PostgreSQLDatabase;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.sql.Statement;
 
 
 @CustomLog
 public class YugabyteDBDatabase extends PostgreSQLDatabase {
 
+    public static final String LOCK_TABLE_NAME = "PG_ADVISORY_LOCK_ALTERNATIVE";
     public YugabyteDBDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
         super(configuration, jdbcConnectionFactory, statementInterceptor);
+        init();
     }
 
     @Override
     protected YugabyteDBConnection doGetConnection(Connection connection) {
-        Statement stmt = null;
-        try {
-            stmt = connection.createStatement();
-            stmt.execute("set yb_silence_advisory_locks_not_supported_error=on;");
-        } catch (SQLException throwable) {
-            LOG.error("Unable to set yb_silence_advisory_locks_not_supported_error ", throwable);
-        }
         return new YugabyteDBConnection(this, connection);
     }
 
@@ -75,4 +70,11 @@ public class YugabyteDBDatabase extends PostgreSQLDatabase {
                 "CREATE INDEX IF NOT EXISTS \"" + table.getName() + "_s_idx\" ON " + table + " (\"success\");";
     }
 
+    private void init() {
+        try {
+            jdbcTemplate.execute("CREATE TABLE IF NOT EXISTS " + LOCK_TABLE_NAME + " (table_hash int PRIMARY KEY, locked bool, last_updated timestamp);");
+        } catch (SQLException e) {
+            throw new FlywaySqlException("Unable to initialize the lock table", e);
+        }
+    }
 }

--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
@@ -30,7 +30,7 @@ import java.sql.SQLException;
 @CustomLog
 public class YugabyteDBDatabase extends PostgreSQLDatabase {
 
-    public static final String LOCK_TABLE_NAME = "PG_ADVISORY_LOCK_ALTERNATIVE";
+    public static final String LOCK_TABLE_NAME = "YB_FLYWAY_LOCK_TABLE";
     public YugabyteDBDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
         super(configuration, jdbcConnectionFactory, statementInterceptor);
         init();

--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
@@ -70,6 +70,11 @@ public class YugabyteDBDatabase extends PostgreSQLDatabase {
                 "CREATE INDEX IF NOT EXISTS \"" + table.getName() + "_s_idx\" ON " + table + " (\"success\");";
     }
 
+    @Override
+    public boolean useSingleConnection() {
+        return false;
+    }
+
     private void init() {
         try {
             jdbcTemplate.execute("CREATE TABLE IF NOT EXISTS " + LOCK_TABLE_NAME + " (table_hash int PRIMARY KEY, locked bool, last_updated timestamp);");

--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabaseType.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabaseType.java
@@ -67,4 +67,9 @@ public class YugabyteDBDatabaseType extends PostgreSQLDatabaseType implements Co
     public String getPluginVersion(Configuration config) {
         return YugabyteDBDatabaseExtension.readVersion();
     }
+
+    @Override
+    public String getDriverClass(String url, ClassLoader classLoader) {
+        return url.startsWith("jdbc:yugabytedb:") ? "com.yugabyte.Driver" : super.getDriverClass(url, classLoader);
+    }
 }

--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBExecutionTemplate.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBExecutionTemplate.java
@@ -5,7 +5,6 @@ import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.internal.exception.FlywaySqlException;
 import org.flywaydb.core.internal.jdbc.JdbcTemplate;
-import org.postgresql.util.PSQLState;
 
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -49,7 +48,8 @@ public class YugabyteDBExecutionTemplate {
                     jdbcTemplate.execute("INSERT INTO " + YugabyteDBDatabase.LOCK_TABLE_NAME + " VALUES (" + tableHash + ", 'false', NOW());");
                     tableEntries.put(tableHash, true);
                 } catch (SQLException e) {
-                    if (PSQLState.UNIQUE_VIOLATION.getState().equals(e.getSQLState())) {
+                    if ("23505".equals(e.getSQLState())) {
+                        // 23505 == UNIQUE_VIOLATION
                         LOG.debug("Table entry already added");
                     } else {
                         throw new FlywaySqlException("Could not initialize lock for table " + YugabyteDBDatabase.LOCK_TABLE_NAME, e);

--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBExecutionTemplate.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBExecutionTemplate.java
@@ -1,0 +1,78 @@
+package org.flywaydb.community.database.postgresql.yugabytedb;
+
+import lombok.CustomLog;
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.exception.FlywaySqlException;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+import org.postgresql.util.PSQLState;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.concurrent.Callable;
+
+@CustomLog
+public class YugabyteDBExecutionTemplate {
+
+    private final Configuration configuration;
+    private final JdbcTemplate jdbcTemplate;
+    private final long tableHash;
+    private final HashMap<Long, Boolean> tableEntries = new HashMap<>();
+
+
+    YugabyteDBExecutionTemplate(Configuration configuration, JdbcTemplate jdbcTemplate, int hash) {
+        this.configuration = configuration;
+        this.jdbcTemplate = jdbcTemplate;
+        this.tableHash = hash;
+    }
+
+    public <T> T execute(Callable<T> callable) {
+        Exception error = null;
+        try {
+            lock();
+            return callable.call();
+        } catch (RuntimeException e) {
+            error = e;
+            throw e;
+        } catch (Exception e) {
+            error = e;
+            throw new FlywayException(e);
+        } finally {
+            unlock(error);
+        }
+    }
+
+    private void lock() throws SQLException {
+        try {
+            if (!tableEntries.containsKey(tableHash)) {
+                try {
+                    jdbcTemplate.execute("INSERT INTO " + YugabyteDBDatabase.LOCK_TABLE_NAME + " VALUES (" + tableHash + ", 'false', NOW());");
+                    tableEntries.put(tableHash, true);
+                } catch (SQLException e) {
+                    if (PSQLState.UNIQUE_VIOLATION.getState().equals(e.getSQLState())) {
+                        LOG.debug("Table entry already added");
+                    } else {
+                        throw new FlywaySqlException("Could not initialize lock for table " + YugabyteDBDatabase.LOCK_TABLE_NAME, e);
+                    }
+                }
+            }
+
+            jdbcTemplate.execute("BEGIN;");
+            jdbcTemplate.queryForBoolean("SELECT locked FROM " + YugabyteDBDatabase.LOCK_TABLE_NAME + " WHERE  table_hash = " + tableHash + " FOR UPDATE;");
+        } catch (SQLException e) {
+            throw new FlywaySqlException("Trying to acquire lock failed", e);
+        }
+    }
+
+    private void unlock(Exception rethrow) throws FlywaySqlException {
+        try {
+            jdbcTemplate.execute("COMMIT;");
+        } catch (SQLException e) {
+            LOG.error("Commit failed: " + e);
+            if (rethrow == null) {
+                throw new FlywaySqlException("Commit failed", e);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Replace use of pg advisory locks in the Postgresql plugin with `SELECT ... FOR UPDATE` in the YugabyteDB plugin

Testing:
Ran the tests in flyway-tests repository

Note:
This PR will later be opened against the upstream main branch.